### PR TITLE
fix(Emails) corrige que los correos se puedan enviar por ssl y tls

### DIFF
--- a/vtlib/Vtiger/Mailer.php
+++ b/vtlib/Vtiger/Mailer.php
@@ -58,13 +58,11 @@ class Vtiger_Mailer extends PHPMailer {
 			$this->Password = Vtiger_Functions::fromProtectedText(decode_html($adb->query_result($result, 0, 'server_password')));
 			$this->SMTPAuth = $adb->query_result($result, 0, 'smtp_auth');
 
-			// To support TLS
 			$hostinfo = explode("://", $this->Host);
-			$smtpsecure = $hostinfo[0];
-			if($smtpsecure == 'tls'){
-				$this->SMTPSecure = $smtpsecure;
-				$this->Host = $hostinfo[1];
-			}
+			$port = explode(":", $hostinfo[1]);
+			$this->SMTPSecure = $hostinfo[0];
+			$this->Host = $hostinfo[1];
+			$this->Port = $port[1];
 			// End
 
 			if(empty($this->SMTPAuth)) $this->SMTPAuth = false;


### PR DESCRIPTION
El puerto y la seguridad no era tenida en cuenta si el servidor saliente era configurado así: ssl://mail.example.com:465 
Con este cambio corrige y toma en cuenta la configuración dada
![outgoing server](https://user-images.githubusercontent.com/52935916/131231569-b63d0cd1-075f-4efc-a512-b7973be20f38.png)
