### PR TITLE
feat(App) Envia a la vista de creación los campos buscados

### DIFF
--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -234,7 +234,7 @@
 								{assign var=SINGLE_MODULE value="SINGLE_$MODULE"}
 								{vtranslate('LBL_NO')} {vtranslate($MODULE, $MODULE)} {vtranslate('LBL_FOUND')}.
 								{if $IS_CREATE_PERMITTED}
-									<a style="color:blue" href="{$MODULE_MODEL->getCreateRecordUrl()}"> {vtranslate('LBL_CREATE')}</a>
+									<a style="color:blue" href="{$MODULE_MODEL->getCreateRecordUrl()}{$searchparams}"> {vtranslate('LBL_CREATE')}</a>
 									{if Users_Privileges_Model::isPermitted($MODULE, 'Import') && $LIST_VIEW_MODEL->isImportEnabled()}
 										{vtranslate('LBL_OR', $MODULE)}
 										<a style="color:blue" href="#" onclick="return Vtiger_Import_Js.triggerImportAction()">{vtranslate('LBL_IMPORT', $MODULE)}</a>

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -105,6 +105,12 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		if(!empty($viewName)) {
 			$this->viewName = $viewName;
 		}
+		$params = $request->get('search_params');
+		$searchparams="";
+		foreach ($params[0] as $key => $val) {
+		   $searchparams .= "&" . $val[0] . "=" . ucfirst($val[2]);		   	 
+		}
+		$viewer->assign('searchparams', $searchparams);
 
 		$this->initializeListViewContents($request, $viewer);
 		$this->assignCustomViews($request,$viewer);


### PR DESCRIPTION
Cuando realizamos una búsqueda de un registro y éste no aparece, procedemos a crearlo, pero nos toca volver a ingresar los datos, esta modificación permite que esos campos anteriormente buscados se autocompleten al crear el nuevo registro.

![Contacts](https://user-images.githubusercontent.com/52935916/131235363-92748ced-e4ad-4f4f-add4-fc27c3eb1e26.gif)
