### PR TITLE
fix(GoogleMaps) corrige error de # en mapas

### DIFF
--- a/layouts/v7/modules/Google/resources/Map.js
+++ b/layouts/v7/modules/Google/resources/Map.js
@@ -51,6 +51,7 @@ Vtiger.Class("Google_Map_Js", {}, {
 	getQueryString : function (address) {
 		address = address.replace(/,/g,' ');
 		address = address.replace(/ /g,'+');
+		address = address.replace("#",'%23');
 		return "https://maps.google.com/maps?q=" + address + "&zoom=14&size=512x512&maptype=roadmap&sensor=false";
 	}
 });


### PR DESCRIPTION
Solución de direcciones que tienen # 
Antes:
![Peek 2021-08-28 22-38](https://user-images.githubusercontent.com/52935916/131237534-413bb086-dc59-4097-bfc0-34a259672ec6.gif)

Despues:
![Peek 2021-08-28 22-39](https://user-images.githubusercontent.com/52935916/131237538-58a1b293-56ee-4058-b9ae-79e72792a3f1.gif)
